### PR TITLE
add gdb to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-apt-get install -y python3 python3-pip python3-dev
+# python is used to run autograder, gdb is used to debug over ssh
+apt-get install -y python3 python3-pip python3-dev gdb
 
 # Installs some English dictionaries 
 # These are needed for the "words" file to exist 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-# python is used to run autograder, gdb is used to debug over ssh
-apt-get install -y python3 python3-pip python3-dev gdb
+# python is used to run autograder scripts
+apt-get install -y python3 python3-pip python3-dev 
+ 
+# gdb can be used to debug over ssh
+apt-get install -y gdb
 
 # Installs some English dictionaries 
 # These are needed for the "words" file to exist 


### PR DESCRIPTION
would resolve #9 if adding this is necessary. running the `time apt-get install -y python3 python3-pip python3-dev gdb` command in the setup.sh script takes 10.734 seconds on average, and running this command without gdb takes 7.187 seconds on average. can test more if needed

installing with gdb
``` 
# first test
real	0m10.589s
user	0m3.813s
sys	0m1.318s

# second test
real	0m11.024s
user	0m3.766s
sys	0m1.397s

# third test
real	0m10.589s
user	0m3.525s
sys	0m1.362s
```

installing without gdb
```
# first test
real	0m5.979s
user	0m2.544s
sys	0m0.498s

# second test
real	0m8.230s
user	0m3.540s
sys	0m0.915s

# third test
real	0m7.353s
user	0m3.164s
sys	0m0.695s
```