### PR TITLE
Parse code for more reliable function removal/extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 gradescope-utils>=0.3.1
+libclang==18.1.1

--- a/tests/utils/driver_running.py
+++ b/tests/utils/driver_running.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 import os
 import utils.common as common
+import utils.parsing as parsing
 
 
 # Class used to represent the result of a student's submission
@@ -130,38 +131,8 @@ def remove_main(input_filename, output_filename):
     output file
     This can be used to later test individual functions without dealing with
     multiple definitions of main.
-
-    This is a pretty inconsistent approach and shouldn't be relied on much.
-    There are other ways using static functions to get around main
     """
-    stack = []
-    inside_main = False
-
-    with open(input_filename, "r") as input_file:
-        lines = input_file.readlines()
-
-    with open(output_filename, "w") as output_file:
-        for line in lines:
-            # strip removes all whitespace at the beginning and end of the
-            # string
-            stripped = line.strip()
-            main_starts = ["int main(", "int main ("]
-
-            if any(stripped.startswith(start) for start in main_starts):
-                inside_main = True
-
-            if not inside_main:
-                output_file.write(line)
-            else:
-                # Keeping track of the curly braces to only remove main
-                for char in line:
-                    if char == "{":
-                        stack.append(char)
-                    elif char == "}":
-                        if stack:
-                            stack.pop()
-                        if not stack:
-                            inside_main = False
+    parsing.remove_functions(input_filename, output_filename, "main")
 
 
 def compile_and_run(

--- a/tests/utils/parsing.py
+++ b/tests/utils/parsing.py
@@ -1,0 +1,104 @@
+"""
+This file contains functions to parse and use entities from C and C++ files
+"""
+
+from clang.cindex import CursorKind, Index, Cursor
+
+
+def find_entity(node: Cursor, kind: CursorKind, name: str) -> Cursor:
+    """
+    Recursively find the desired entity as a Cursor from the supplied node
+    """
+
+    if node.kind == kind and node.spelling == name:
+        # found node!
+        return node
+
+    for child in node.get_children():
+        entity = find_entity(child, kind, name)
+
+        if entity is not None:
+            return entity
+
+    return None
+
+
+def get_cursor_range(cursor: Cursor) -> tuple[int, int]:
+    """
+    Returns offset position and length of a Cursor in the source file
+    """
+
+    start = cursor.extent.start.offset
+    end = cursor.extent.end.offset
+
+    return (start, end - start)
+
+
+def get_function_ranges(input_filename: str, output_filename: str,
+                        function_names: tuple[str, ...]) -> list[tuple[int,
+                                                                       int]]:
+    """
+    Get the ranges
+    """
+
+    # init Index to parse file and get TranslationUnit
+    index = Index.create()
+    tu = index.parse(input_filename)
+
+    # store entity ranges for requested functions (if found)
+    entity_ranges = []
+    for func_name in function_names:
+        entity = find_entity(tu.cursor, CursorKind.FUNCTION_DECL, func_name)
+        if entity is not None:
+            entity_ranges.append(get_cursor_range(entity))
+
+    # return ranges sorted by start position
+    return sorted(entity_ranges, key=lambda x: x[0])
+
+
+def extract_functions(input_filename: str, output_filename: str,
+                      *function_names: str) -> None:
+    """
+    Extract the desired function names from the input file into the output file
+    """
+
+    function_ranges = get_function_ranges(input_filename, output_filename,
+                                          function_names)
+
+    contents = []
+    with open(input_filename, 'r') as input_file:
+        for (offset, length) in function_ranges:
+            # add function to content to write
+            input_file.seek(offset)
+            contents.append(input_file.read(length))
+
+    with open(output_filename, 'w') as output_file:
+        output_file.write('\n\n'.join(contents))
+
+
+def remove_functions(input_filename: str, output_filename: str,
+                     *function_names: str) -> None:
+    """
+    Remove specified function names from the input file and place in the output
+    file
+    """
+
+    function_ranges = get_function_ranges(input_filename, output_filename,
+                                          function_names)
+
+    contents = []
+    with open(input_filename, 'r') as input_file:
+        prev_pos = 0
+        for (offset, length) in function_ranges:
+            # add file contents excluding function to remove
+            contents.append(input_file.read(offset - prev_pos))
+            input_file.seek(offset + length)
+
+            # store new start position (end of removed function)
+            prev_pos = offset + length
+
+        # finish reading file contents
+        contents.append(input_file.read())
+
+    with open(output_filename, 'w') as output_file:
+        output_file.write(''.join(contents))


### PR DESCRIPTION
The previous method used to extract the `main` function from a file can be unreliable (e.g., `int  main  (` would result in incorrect parsing). This intends to remedy the issue by using `libclang` to parse the source code to remove the `main` function. The installation of `libclang` adds about 1.2 seconds to the autograder initialization process.

Additionally, this exposes functions for use in the autograder to extract and remove specific functions (apart from just the `main` function), allowing more customizable uses of the autograder (e.g., use a different implementation of a function, test whether student are using user-defined functions).