### PR TITLE
Ensure the Test01Setup suite always runs first

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ or clone the repository
 ## Example Usage  
 This framework is pre-configured as a working autograder for the example sample code in the `example_sample_code` directory. You can use this to test how the autograder works before making modifications.  
 
-1. Run the `zipper.sh` script to generate a zip file for Gradescope.  
+1. Run the `zipper.sh` script to generate a zip file of the autograder for Gradescope.  
 2. Zip the `example_sample_code` directory and upload it to Gradescope as a submission. You should see all test cases pass.  
-3. Modify the `test.py` file inside `example_sample_code` to experiment with different grading behaviors. Many autograding styles are showcased in the file.
+3. Modify the `test.py` file to experiment with different grading behaviors. Many autograding styles are showcased in the file.
 4. Use **"Debug with SSH"** in Gradescope to inspect the environment and troubleshoot any issues.  
 
 ## Files (and what they do)

--- a/run_tests.py
+++ b/run_tests.py
@@ -11,10 +11,44 @@ Gradescope
 import unittest
 from gradescope_utils.autograder_utils.json_test_runner import JSONTestRunner
 
+
+SETUP_CLASS_NAME = "Test01Setup"
+
+
+def _iter_test_cases(suite):
+    """Yield concrete test cases from a potentially nested suite."""
+    for test in suite:
+        if isinstance(test, unittest.TestSuite):
+            yield from _iter_test_cases(test)
+        else:
+            yield test
+
+
+def _prioritize_setup_suite(discovered_suite):
+    """
+    Move tests from Test01Setup to the front while preserving
+    relative order for all tests.
+    """
+    setup_tests = []
+    other_tests = []
+
+    for test in _iter_test_cases(discovered_suite):
+        if test.__class__.__name__ == SETUP_CLASS_NAME:
+            setup_tests.append(test)
+        else:
+            other_tests.append(test)
+
+    ordered_suite = unittest.TestSuite()
+    ordered_suite.addTests(setup_tests)
+    ordered_suite.addTests(other_tests)
+    return ordered_suite
+
+
 # This will run any testing scripts it can find and then writes all the results
 # to the results.json
 if __name__ == "__main__":
-    suite = unittest.defaultTestLoader.discover("tests")
+    discovered_suite = unittest.defaultTestLoader.discover("tests")
+    suite = _prioritize_setup_suite(discovered_suite)
     with open("/autograder/results/results.json", "w", encoding="utf-8") as f:
         JSONTestRunner(visibility="visible", stream=f).run(suite)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -26,6 +26,14 @@ class Test01Setup(unittest.TestCase):
     """
     Collection of test cases used to check and move files into the correct
     location and compile the main executable.
+
+    Test case classes and the test cases within them are run in alphabetical
+    order, so use a naming scheme like Test01, Test02, etc. to control the
+    flow of the tests.
+
+    However, the class named `Test01Setup` is specifically prioritized in
+    run_tests.py, so it will always run first regardless of alphabetical
+    order.
     """
 
     # Files that must be in their submission


### PR DESCRIPTION
Modifies the `run_tests.py` to ensure that any test within `Test01Setup` runs first.

In situations where the `TestXX` prefixes naming style isn't used, this fix will ensure that the setup suite will still run first. 

## Testing

Tested on Gradescope by naming some of the test suites without the `TestXX` prefixes and then seeing tests fail unless I run the tests through the new `_prioritize_setup_suite` method. 